### PR TITLE
fix: target 'es2019' for swc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,29 @@
 import defu from 'defu'
 import { name, version } from '../package.json'
+import type { Options } from '@swc/core'
 
 function swcModule () {
   const { nuxt } = this
 
-  const swcOptions = defu(nuxt.options.build.swc, {
+  const swcOptions: Options = defu(nuxt.options.build.swc, {
     // sync: true,
     sourceMaps: false,
     jsc: {
+      target: 'es2019',
       parser: {
         dynamicImport: true
       }
     }
-  })
+  } as Options)
 
   const swcTSOptions = defu(swcOptions, {
     jsc: {
+      target: 'es2019',
       parser: {
         syntax: 'typescript'
       }
     }
-  })
+  } as Options)
 
   nuxt.options.extensions.push('ts')
   nuxt.options.build.additionalExtensions = ['ts', 'tsx']

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ function swcModule () {
 
   const swcTSOptions = defu(swcOptions, {
     jsc: {
-      target: 'es2019',
       parser: {
         syntax: 'typescript'
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ function swcModule () {
         syntax: 'typescript'
       }
     }
-  } as Options)
+  })
 
   nuxt.options.extensions.push('ts')
   nuxt.options.build.additionalExtensions = ['ts', 'tsx']


### PR DESCRIPTION
Previously it was possible to receive the error `ReferenceError: Cannot access 'inject' before initialization` because of the implementation of promises produced code like (when plugins injected something into context):

```js
switch (a) {
  case 9:
    function inject(key, value) {
        // ...
    }
    // Inject runtime config as $config
    inject('config', config)
    // ...
  case 18:
    return test(app.context, inject)
}
```